### PR TITLE
reflect new repo on Github; include GTEST_DIR in build command

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,11 +1,16 @@
-A ruby interface to the keyczar crypto library. Provides basic encrypt, decrypt, sign and verify methods.  This is just a wrapper around the c++ version of keyczar. You will need keyczar-cpp in order to use it. Find keyczar-cpp here: http://code.google.com/p/keyczar/downloads/list
+A ruby interface to the keyczar crypto library. Provides basic encrypt, decrypt, sign and verify methods.  This is just a wrapper around the c++ version of keyczar. 
 
-For now, we assume that keyczar-cpp was installed with the prefix 
+You will need keyczar-cpp in order to use it. Download a zip or clone the repo here: https://github.com/google/keyczar
+
+keyczar requires gtest. If you don't already have it, download a copy from https://code.google.com/p/googletest/downloads
+and unpack it in a convenient location (you'll need the path for the build command below).
+
+For now, we assume that keyczar was installed with the prefix 
 /usr/local. You should be able to install it with these commands:
 
-  $ cd keyczar-cpp/src 
-  $ sh ./tools/swtoolkit/hammer.sh --mode=opt-linux --compat
-  $ sh ./tools/swtoolkit/hammer.sh --mode=opt-linux --compat install
+  $ cd cpp/src 
+  $ sh ./tools/swtoolkit/hammer.sh -D GTEST_DIR=YOUR_GTEST_PATH --mode=opt-linux --compat
+  $ sh ./tools/swtoolkit/hammer.sh -D GTEST_DIR=YOUR_GTEST_PATH --mode=opt-linux --compat install
  
 replace opt-linux above by opt-bsd or opt-mac depending on your system
 


### PR DESCRIPTION
Google moved keyczar from code.google.com over to Github. Also, gtest is a now a build dependency.
